### PR TITLE
Update Vite dependence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ dist-ssr
 *.local
 
 # Editor directories and files
-.vscode/*
 !.vscode/extensions.json
 .idea
 .DS_Store

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,27 +1,27 @@
 {
-    "version": "2.0.0",
-    "tasks": [
-        {
-            "label": "Task 1",
-            "type": "npm",
-            "script": "dev",
-            "runOptions": { "runOn": "folderOpen" }
-        },
-        {
-            "label": "Task 3",
-            "type": "shell",
-            "command": "git",
-            "args": ["checkout", "main"],
-            "group": { "kind": "build", "isDefault": true },
-            "runOptions": { "runOn": "folderOpen" }
-        },
-        {
-            "label": "Task 2",
-            "type": "shell",
-            "command": "git",
-            "args": ["pull","origin", "main"],
-            "group": { "kind": "build", "isDefault": true },
-            "runOptions": { "runOn": "folderOpen" }
-        }
-    ]
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Task 1",
+      "type": "npm",
+      "script": "dev",
+      "runOptions": { "runOn": "folderOpen" }
+    },
+    {
+      "label": "Task 3",
+      "type": "shell",
+      "command": "git",
+      "args": ["checkout", "main"],
+      "group": { "kind": "build", "isDefault": true },
+      "runOptions": { "runOn": "folderOpen" }
+    },
+    {
+      "label": "Task 2",
+      "type": "shell",
+      "command": "git",
+      "args": ["pull", "origin", "main"],
+      "group": { "kind": "build", "isDefault": true },
+      "runOptions": { "runOn": "folderOpen" }
+    }
+  ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,27 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Task 1",
+            "type": "npm",
+            "script": "dev",
+            "runOptions": { "runOn": "folderOpen" }
+        },
+        {
+            "label": "Task 3",
+            "type": "shell",
+            "command": "git",
+            "args": ["checkout", "main"],
+            "group": { "kind": "build", "isDefault": true },
+            "runOptions": { "runOn": "folderOpen" }
+        },
+        {
+            "label": "Task 2",
+            "type": "shell",
+            "command": "git",
+            "args": ["pull","origin", "main"],
+            "group": { "kind": "build", "isDefault": true },
+            "runOptions": { "runOn": "folderOpen" }
+        }
+    ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "postcss": "^8.4.33",
         "prettier": "^3.2.1",
         "tailwindcss": "^3.4.1",
-        "vite": "^5.0.8"
+        "vite": "^5.0.12"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2073,9 +2073,9 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.11.tgz",
-      "integrity": "sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
+      "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "postcss": "^8.4.33",
     "prettier": "^3.2.1",
     "tailwindcss": "^3.4.1",
-    "vite": "^5.0.8"
+    "vite": "^5.0.12"
   },
   "dependencies": {
     "swiper": "^11.0.5"


### PR DESCRIPTION
- Command used for that consequence: `npm install vite --save-dev`.

- The package or tool was not installed globally in my project.

version of the dependency: 5.0.12.